### PR TITLE
fix(installationInstructions): add 'troubleshooting.md' and increase required versions

### DIFF
--- a/docs/sdk/cli.md
+++ b/docs/sdk/cli.md
@@ -17,7 +17,7 @@ Next, install the viewar-cli globally by entering the following command into you
 
 `npm install -g viewar-cli`
 
-You only need to install this tool once. When out of date, it will alert you and provide update instructions.
+> if you get errors, installing 'viewar-cli', have a look at the [troubleshooting](./troubleshooting) page.
 
 #### create account
 

--- a/docs/sdk/cli.md
+++ b/docs/sdk/cli.md
@@ -7,9 +7,9 @@ title: CLI Usage
 
 First, make sure that you have the following prerequisites installed:
 
-- [node.js](https://nodejs.org/en/download/) \(&gt;= v6.0.0 and &lt;= v10.0.0\)
-- [npm](https://www.npmjs.com/) \(&gt;= v3.0.0\)
-- [git](https://meet.google.com/linkredirect?authuser=0&dest=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fgit-osx-installer%2Ffiles%2F)
+- [node.js](https://nodejs.org/en/download/) (&gt;= v10.0.0)
+- [npm](https://www.npmjs.com/) (&gt;= v5.6.0)
+- [git](https://git-scm.com/)
 
 #### install viewar-cli
 

--- a/docs/sdk/cli.md
+++ b/docs/sdk/cli.md
@@ -17,7 +17,7 @@ Next, install the viewar-cli globally by entering the following command into you
 
 `npm install -g viewar-cli`
 
-> if you get errors, installing 'viewar-cli', have a look at the [troubleshooting](./troubleshooting) page.
+> if you have problems, installing 'viewar-cli', have a look at the [troubleshooting](./troubleshooting) page.
 
 #### create account
 

--- a/docs/sdk/cli.md
+++ b/docs/sdk/cli.md
@@ -17,8 +17,6 @@ Next, install the viewar-cli globally by entering the following command into you
 
 `npm install -g viewar-cli`
 
-\(You might need to use `sudo npm install -g viewar-cli` to have the right permissions.\)
-
 You only need to install this tool once. When out of date, it will alert you and provide update instructions.
 
 #### create account

--- a/docs/sdk/troubleshooting.md
+++ b/docs/sdk/troubleshooting.md
@@ -1,0 +1,16 @@
+---
+id: troubleshooting
+title: Trouble Shooting
+---
+
+## EACCES: permission denied
+
+if you see this error, try to fix the directory permissions with the following commands  
+_(you can copy the whole block into your terminal)_
+
+```bash
+# set directory to be readable by owner and system \
+chmod -R 0775 /usr/local/lib/node_modules && \
+# set the owner to your current user \
+sudo chown -R `whoami` /usr/local/lib/node_modules
+```

--- a/docs/sdk/troubleshooting.md
+++ b/docs/sdk/troubleshooting.md
@@ -7,12 +7,12 @@ title: Trouble Shooting
 
 ### EACCES: permission denied
 
-if you see this error, try to fix the directory permissions with the following commands  
-_(you can copy the whole block into your terminal)_
+if you see this error, try to fix the directory permissions with the following commands
 
 ```bash
-# set directory to be readable by owner and system \
-chmod -R 0775 /usr/local/lib/node_modules && \
-# set the owner to your current user \
-sudo chown -R `whoami` /usr/local/lib/node_modules
+# set directory to be readable by owner and system
+sudo chmod -R 0775 /usr/local/lib/node_modules
+
+# set the owner to your current user
+USER=`whoami` sudo chown -R $USER /usr/local/lib/node_modules
 ```

--- a/docs/sdk/troubleshooting.md
+++ b/docs/sdk/troubleshooting.md
@@ -16,3 +16,11 @@ sudo chmod -R 0775 /usr/local/lib/node_modules
 # set the owner to your current user
 USER=`whoami` sudo chown -R $USER /usr/local/lib/node_modules
 ```
+
+### no root permissions at all
+
+if you are working on a machine, where you don't have root permissions,  
+you can try to use the CLI via [NPX](https://www.npmjs.com/package/npx)
+_(already included in your NodeJS installation)_
+
+for example: `npx viewar-cli init`

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,7 +1,13 @@
 {
   "docs": {
     "ViewAR": ["introduction", "stack", "creating_apps", "faq"],
-    "SDK": ["sdk/introduction", "sdk/cli", "sdk/basic_concepts", "sdk/quickstart"],
+    "SDK": [
+      "sdk/introduction",
+      "sdk/cli",
+      "sdk/basic_concepts",
+      "sdk/quickstart",
+      "sdk/troubleshooting"
+    ],
     "Tutorials": [
       "tutorials/overview",
       {

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -46,7 +46,7 @@ const siteConfig = {
   algolia:                {
     apiKey:         '5207094edcc772e8784736cd40203ef0',
     indexName:      'viewar',
-    placeholder:    'Search SDK',
+    placeholder:    'Search',
     algoliaOptions: {}, // Optional, if provided by Algolia
   },
   // For no header links in the top nav bar -> headerLinks: [],


### PR DESCRIPTION
docs: sdk/cli - increase min. required versions of npm an node
* **require node >= 10**
  current @latest is at "12.8.0"(!)
  and most module developers are dropping support for older node versions (<= 8),
  as v8 is now over two years old (released on 2017-05-30)
 * **require npm >= 5.6.0**  _(included in NodeJS > 10)_
   _we are currently at version 6.13.0_

* add troubleshooting info / link
* add troubleshooting page:  
  ![image](https://user-images.githubusercontent.com/5007050/68870220-d4ccbe80-06fa-11ea-88a0-9e94acb6312f.png)