### PR TITLE
[fix] duplicated headlines/sections in cli installation instructions

### DIFF
--- a/docs/sdk/cli.md
+++ b/docs/sdk/cli.md
@@ -25,12 +25,7 @@ Create a free ViewAR [account](https://developer.viewar.com/user/register). You 
 
 `viewar login`
 
----
-
-id: initialize_project
-title: Initialize an App/Template
-
----
+#### initialize a project
 
 Initialize a new JavaScript application by opening the terminal in your project directory and entering the following command:
 

--- a/docs/sdk/cli.md
+++ b/docs/sdk/cli.md
@@ -52,7 +52,7 @@ Next, install the viewar-cli globally by entering the following command into you
 You will only need to install this tool once.  
 It will alert you when it's out of date, and provide instruction on how to update it.
 
-#### Initialization
+### Initialization
 
 Initialize a new javascript application by opening the terminal in your project directory and entering the following command:
 


### PR DESCRIPTION
at the moment we have duplicated content on `/docs/sdk/cli.md`:

```markdown
## Prerequisites

#### install viewar-cli
#### create account
#### initialize a project <--- NEW instead of copied md-header  --->

## viewar-cli
### Installation
### Initialization
```